### PR TITLE
use (TokenParser | None) instead of Maybe[TokenParser]

### DIFF
--- a/src/async_parser/async_parser.pony
+++ b/src/async_parser/async_parser.pony
@@ -44,26 +44,26 @@ type ParseStatus is (ParseSuccess | ParseContinue | ParseFailed)
 
 class ParseResult
   let status: ParseStatus
-  let parser: Maybe[TokenParser]
+  let parser: (TokenParser | None)
   let state: ParserState
   let errorMessage: Stringable
 
   new success(state': ParserState) =>
     status = ParseSuccess
     state = state'
-    parser = Maybe[TokenParser].none()
+    parser = None
     errorMessage = None
 
   new cont(state': ParserState, parser': TokenParser) =>
     status = ParseContinue
-    parser = Maybe[TokenParser](parser')
+    parser = parser'
     state = state'
     errorMessage = None
 
   new failed(state': ParserState, message': String) =>
     status = ParseFailed
     state = state'
-    parser = Maybe[TokenParser].none()
+    parser = None
     errorMessage = message'
 
 interface GrammarElement


### PR DESCRIPTION
A small change to use a union type instead of `Maybe[A]`.

To get a `TokenParser` from the `parser: (TokenParser | None)` field, you can do:

``` pony
try
  let p = parser as TokenParser
  // do some work
else
  // parser was None
end
```
